### PR TITLE
fix: $app/env to $app/environment

### DIFF
--- a/src/FullscreenManager.svelte
+++ b/src/FullscreenManager.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { browser } from "$app/env";
+  import { browser } from "$app/environment";
 
   import { onMount, onDestroy } from "svelte";
   import { screenfull } from "./libs/screenfull.js";


### PR DESCRIPTION
Fix import to work with newer versions of SvelteKit. 
See [PR6175](https://github.com/sveltejs/kit/pull/6334)